### PR TITLE
Fix XML encoding on Windows, re-enable tests on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -115,7 +115,7 @@ In order to build Hydrogen on Debian-based Systems, you can use the
 following command to install all basic and some optional requirements.
 
 ``` bash
-$ sudo apt-get install qtbase5-dev qtbase5-dev-tools            \
+$ sudo apt-get install cmake qtbase5-dev qtbase5-dev-tools  \
 	qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev  \
 	libarchive-dev libsndfile1-dev libasound2-dev liblo-dev \
 	libpulse-dev libcppunit-dev liblrdf-dev                 \

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -189,7 +189,7 @@ void SampleEditor::getAllFrameInfos()
 	
 	assert( pInstrument );
 
-	InstrumentComponent *pCompo = pInstrument->get_component(0);
+	InstrumentComponent *pCompo = pInstrument->get_component( m_nSelectedComponent );
 	assert( pCompo );
 
 	InstrumentLayer *pLayer = pCompo->get_layer( m_nSelectedLayer );
@@ -395,7 +395,7 @@ void SampleEditor::createNewLayer()
 		
 		H2Core::InstrumentLayer *pLayer = nullptr;
 		if( pInstrument ) {
-			pLayer = pInstrument->get_component(0)->get_layer( m_nSelectedLayer );
+			pLayer = pInstrument->get_component( m_nSelectedComponent )->get_layer( m_nSelectedLayer );
 
 			// insert new sample from newInstrument
 			pLayer->set_sample( pEditSample );
@@ -576,7 +576,7 @@ void SampleEditor::on_PlayOrigPushButton_clicked()
 	 *instrument. Otherwise pInstr would be deleted if consumed by preview_instrument.
 	*/
 	Instrument *pTmpInstrument = Instrument::load_instrument( pInstr->get_drumkit_name(), pInstr->get_name() );
-	auto pNewSample = Sample::load( pInstr->get_component(0)->get_layer( selectedlayer )->get_sample()->get_filepath() );
+	auto pNewSample = Sample::load( pInstr->get_component( m_nSelectedComponent )->get_layer( selectedlayer )->get_sample()->get_filepath() );
 
 	if ( pNewSample != nullptr ){
 		int length = ( ( pNewSample->get_frames() / pNewSample->get_sample_rate() + 1) * 100 );


### PR DESCRIPTION
The unit tests on Windows seem to have been broken for a while, but the results of the tests have also been ignored for that time.

This PR fixes the issue that shows up in Windows testing (but doesn't show up in the mac / Linux tests), namely that the XML helper would write XML files using the default encoding for the platform. If non-ASCII characters were encoded, this would break *very subtly* on Windows since the default encoding isn't UTF-8, but the generated XML is explicitly UTF-8.

Since the unit tests will now pass on Windows, this PR re-enables checking the result on Windows.